### PR TITLE
Blogpost vom letzten Mal anzeigen

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 </article>
 
 $partial("templates/next-meetup.html")$
+$partial("templates/last-meetup.html")$
 
 <article>
   <h1>Wo?</h1>

--- a/site.hs
+++ b/site.hs
@@ -68,15 +68,18 @@ main = do
               bimap headMay lastMay
                 $ partition (\x -> localMeszDay (_date x) >= currDay) meetups
             postBody p = loadSnapshotBody (itemIdentifier p) "html-post"
-            meetupField (Meetup day post) = do
+            meetupField key (Meetup day post) = do
               body <- postBody post
-              pure $ constField "next-meetup-date" (formatTime curryClubLocale "%d.%m.%Y" day)
-                <> constField "next-meetup-body" body
+              pure $ constField (key ++ "-date") (formatTime curryClubLocale "%d.%m.%Y" day)
+                <> constField (key ++ "-body") body
+            mayField = maybe (pure mempty) . meetupField
 
-        nextMField <- maybe (pure mempty) meetupField nextM
+        nextMField <- mayField "next-meetup" nextM
+        lastMField <- mayField "last-meetup" lastM
         let indexCtx =
               listField "posts" postCtx (return $ reverse posts)
               <> nextMField
+              <> lastMField
               <> constField "title" "Home"
               <> defaultContext
 

--- a/templates/last-meetup.html
+++ b/templates/last-meetup.html
@@ -1,0 +1,8 @@
+<article>
+  <header>
+    <h1>Vom letzten Mal</h1>
+  </header>
+
+  $last-meetup-body$
+
+</article>


### PR DESCRIPTION
Dieser Change zeigt ein weiteres Feld an, das den Blockpost für das letzte Treffen nochmal anzeigt.

Ursprünglich hatten wir angedacht, dass es immer einen Blogpost zur Nachbearbeitung gibt, aber anscheinend ist es einfacher, das einfach in den Treffensartikel einzupflegen.

Dementsprechend sollten wir die Artikel ab jetzt auch in der Gegenwart schreiben (nicht „wird halten“, sondern „hält“), damit wir nicht zu viel anpassen müssen.

Ist das gut so?
cc @lukasepple @timjb @iblech 
