### PR TITLE
Ein paar Formulierungen umgeschrieben.

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <h2><strong>Nachbereitung</strong> zu unserem Haskell-Workshop vom 20.12.2015</h2>
   <ul>
     <li><a href="https://ola.pads.ccc.de/haskell-workshop-2015b-danach">Das Nachbereitungspad für weiterführende Inhalte und Feedback</a></li>
-    <li><a href="https://curry-club-aux.github.io/haskell-workshop/uebung.pdf">Die Übungsaufgaben vom Workshop und ein paar neue zum Weiterüben (für AnfängerInnen)</a></li>
+    <li><a href="https://curry-club-aux.github.io/haskell-workshop/uebung.pdf">Die Übungsaufgaben vom Workshop und ein paar neue zum Weiterüben (für Anfängerinnen)</a></li>
     <li><a href="https://curry-club-aux.github.io/haskell-workshop/uebung2.pdf">Die Übungsaufgaben vom Workshop und ein paar neue zum Weiterüben (für Fortgeschrittene)</a></li>
     <li><a href="http://curry-club-augsburg.de/posts/2015-10-27-monaden-in-haskell.html">Tutorial zur IO- und State-Monade von Ingo</a></li>
     <li><a href="https://www.youtube.com/playlist?list=PLwpepnYDFK9PtCd9JLwa6H1LhVrGEbcu_">Ingos Erklärungen als Videos auf Youtube</a></li>

--- a/posts/2015-12-09-zweiter-workshop.md
+++ b/posts/2015-12-09-zweiter-workshop.md
@@ -12,15 +12,15 @@ author: Tim Baumann
   </a>
 </div>
 
-Liebe Freundinnen und Freunde der Sonne!
+Liebe Freundinnen der Sonne!
 
 Wir, der Curry Club Augsburg, laden alle Interessierten herzlich zu der Fortsetzung unseres
 **Haskell-Workshops** ein. Diese findet am **20. Dezember 2015**,
 einem Sonntag, von 9:00 Uhr bis 17:00 Uhr im **OpenLab Augsburg** statt. Wie beim ersten Mal ist die Teilnahme kostenlos.
 
-Zielgruppe des Workshops sind alle Teilnehmenden des ersten Workshops sowie Einsteigerinnen und Einsteiger auf allen Fortschrittslevels.
+Zielgruppe des Workshops sind alle Teilnehmerinnen des ersten Workshops sowie Einsteigerinnen auf allen Fortschrittslevels.
 
-Mit den Teilnehmenden vom letzten Mal werden wir dort weitermachen, wo wir das letzte Mal aufgehört haben.
+Mit den Teilnehmerinnen vom letzten Mal werden wir dort weitermachen, wo wir das letzte Mal aufgehört haben.
 Während es damals darum ging die Basics zu lernen, wollen wir dieses Mal auf folgende Fragen eingehen:
 
 * Welche verwendungsfertige Funktionen gibt es in der Standardbibliothek und auf [Hackage][hackage]?
@@ -31,7 +31,7 @@ Während es damals darum ging die Basics zu lernen, wollen wir dieses Mal auf fo
 Am Anfang werden wir Monaden wiederholen. Ingo hat dazu auch einen [eigenen Blog-Post][monad-tutorial] geschrieben. Ihr tut euch mit Monaden erheblich leichter, wenn ihr diesen Artikel vor dem Workshop liest!
 Falls ihr das letzte Mal nicht fertig geworden seid, dann ist das kein Problem. Dann könnt ihr einfach das [Übungsblatt][uebung] weiter bearbeiten und wir helfen euch dabei.
 
-Für Neueinsteigerinnen und Neueinsteiger wird es eine eigene Gruppe geben.
+Für Neueinsteigerinnen wird es eine eigene Gruppe geben.
 Teilnahmevoraussetzung für Neulinge ist entweder Erfahrung mit einer beliebigen anderen
 Programmiersprache oder Vertrautheit mit mathematisch/abstraktem Denken.
 

--- a/templates/default.html
+++ b/templates/default.html
@@ -36,7 +36,8 @@
     <footer class="footer">
       Mit viel <b>&lambda;</b> und mit Hilfe von <a href="http://jaspervdj.be/hakyll">Hakyll</a> erstellt.
       Schau dir den <a href="https://github.com/curry-club-aux/curry-club-augsburg.de">Quellcode</a> an und verbessere ihn!<br />
-      Sofern nicht anders angegeben, stehen Design, Bilder, Webseite und Texte unter <a href="https://creativecommons.org/licenses/by/3.0/de/">CC BY 3.0 DE</a> und Codeschnipsel unter <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>.
+      Sofern nicht anders angegeben, stehen Design, Bilder, Webseite und Texte unter <a href="https://creativecommons.org/licenses/by/3.0/de/">CC BY 3.0 DE</a> und Codeschnipsel unter <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>.<br />
+      Q: Warum sind alle Formulierungen auf der Website weiblich? A: Weil wir’s können.
     </footer>
   </body>
 </html>

--- a/templates/next-meetup.html
+++ b/templates/next-meetup.html
@@ -14,5 +14,5 @@ $endfor$
 
 <article>
   <p class="deemph">Du schreibst ein cooles Haskell-Projekt, hast eine tolle neue funktionale Programmiersprache entdeckt, oder verstehst endlich, wie Schach-AIs funktionieren? Dann halte einen Vortrag! Die Organisation geht über unsere <a href="http://lists.curry-club-augsburg.de/listinfo/curry-talk">Mailingliste</a>.</p>
-  <p class="deemph">Kurzvorträge (< 10 min) können auch unangekündigt gehalten werden, in Absprache mit dem jeweiligen Organisator.</p>
+  <p class="deemph">Kurzvorträge (< 10 min) können auch unangekündigt gehalten werden, in Absprache mit der jeweiligen Organisatorin.</p>
 </article>


### PR DESCRIPTION
Ich habe versucht, für die letzten paar Artikel die Diskussion von https://github.com/curry-club-aux/curry-club-augsburg.de/commit/4c56f103e7dd61638c76bacebbeb6c6babefd5ed umzusetzen.

Es sind weniger Stellen, als ich mir vorgestellt hatte. Ich finde es besser als umständliche inklusive Verdoppelungen von Wörtern oder Binnen-Is. Sprachwissenschaftlich natürlich fragwürdig, aber eine erfrischend andere Herangehensweise. :)
